### PR TITLE
Rainbow rod no longer has tile sliding.

### DIFF
--- a/AdventureProjectile.cs
+++ b/AdventureProjectile.cs
@@ -1,5 +1,7 @@
+using Microsoft.Xna.Framework;
 using PvPAdventure.System;
 using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace PvPAdventure;
@@ -18,6 +20,13 @@ public class AdventureProjectile : GlobalProjectile
         }
 
         return null;
+    }
+
+    public override bool OnTileCollide(Projectile projectile, Vector2 oldVelocity)
+    {
+        if (projectile.type == ProjectileID.RainbowRodBullet)
+            projectile.Kill();
+        return true;
     }
 
     public override void SetDefaults(Projectile entity)


### PR DESCRIPTION
The rainbow rod projectile is now killed when it comes into contact with a tile.