### PR TITLE
Added support for duke fishron drops to recipes

### DIFF
--- a/System/RecipeManager.cs
+++ b/System/RecipeManager.cs
@@ -38,7 +38,6 @@ namespace PvPAdventure.System
 
                     Recipe.Create(lootTable[i])
                         .AddIngredient(lootTable[j], amountOfMaterial)
-                        .AddTile(TileID.WorkBenches)
                         .Register();
                 }
             }


### PR DESCRIPTION
1 of any duke fishron drop can now be made using the same 3 of any other duke fishron drop. Additionally, made duplicate drop recipes craftable by hand since they had almost no reason to require a workbench.