### PR TITLE
Fixed item duplication with recipes

### DIFF
--- a/System/RecipeManager.cs
+++ b/System/RecipeManager.cs
@@ -38,6 +38,7 @@ namespace PvPAdventure.System
 
                     Recipe.Create(lootTable[i])
                         .AddIngredient(lootTable[j], amountOfMaterial)
+                        .DisableDecraft()
                         .Register();
                 }
             }


### PR DESCRIPTION
Disabled shimmer decrafting alternative recipes drops, which caused items to duplicate.