### PR TITLE
Tiki armor changes and zoom changes

### DIFF
--- a/AdventurePlayer.cs
+++ b/AdventurePlayer.cs
@@ -697,4 +697,31 @@ public class AdventurePlayer : ModPlayer
             }
         }
     }
+    public class ForceZoom : ModPlayer
+    {
+        // Configuration
+        private const float BaseMinimumZoom = 1.0f; // Normal minimum zoom (100%)
+        // Runtime variables
+        private float currentMinimumZoom;
+        private float playerZoomTarget;
+
+        public override void PostUpdate()
+        {
+            // 1. Determine current minimum based on equipment
+            currentMinimumZoom = Player.armor[0].type == ItemID.Goggles
+                ? BaseMinimumZoom 
+                : BaseMinimumZoom;
+
+            // 2. Get the player's current zoom target from the game
+            playerZoomTarget = Main.GameZoomTarget;
+
+            // 3. Enforce minimum zoom but allow zooming in beyond
+            if (playerZoomTarget < currentMinimumZoom)
+            {
+                Main.GameZoomTarget = currentMinimumZoom;
+                Main.GameViewMatrix.Zoom = new Vector2(currentMinimumZoom);
+            }
+
+        }
+    }
 }

--- a/AdventurePlayer.cs
+++ b/AdventurePlayer.cs
@@ -76,7 +76,6 @@ public class AdventurePlayer : ModPlayer
             adventurePlayer.Deaths = Deaths;
         }
     }
-
     public sealed class ItemPickup(int[] items) : IPacket<ItemPickup>
     {
         public int[] Items { get; } = items;
@@ -624,6 +623,7 @@ public class AdventurePlayer : ModPlayer
             PvPImmuneTime = adventureConfig.Combat.StandardInvincibilityFrames;
     }
 
+
     public override bool OnPickup(Item item)
     {
         // FIXME: This could work for non-modded items, but I'm not so sure the item type ordinals are determinant.
@@ -681,5 +681,20 @@ public class AdventurePlayer : ModPlayer
     public override string ToString()
     {
         return $"{Player.whoAmI}/{Player.name}/{DiscordUser?.Id}";
+    }
+    // Handles the set bonus effects
+    public class TikiArmorModPlayer : ModPlayer
+    {
+        public override void PostUpdateEquips()
+        {
+            // Check if wearing full Tiki Armor
+            if (Player.armor[0].type == ItemID.TikiMask &&
+                Player.armor[1].type == ItemID.TikiShirt &&
+                Player.armor[2].type == ItemID.TikiPants)
+            {
+                Player.maxMinions += 1;
+                Player.noKnockback = true;
+            }
+        }
     }
 }

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -362,3 +362,5 @@ Mods: {
 		Bounty.CollectedAllMechanicalBossSouls: "[c/32FF82:Cries of tortured souls emanate from the Bounty Shop...]"
 	}
 }
+
+ArmorSetBonus.Tiki: Set bonus: Knockback immunity,  increases whip range by 20% , +2 minion slots. Does not apply if name contains "ss"


### PR DESCRIPTION
Tiki armor full set grants kb immunity and an extra slot (2 in total)
Tiki armor set bonus description changed to match this this
Also capped zoom at 100% to prevent betterZ shenanigans
Also I know ts sucks but its game branch and it works so who gives a gaf