### PR TITLE
Changed loot rewards for boss enemies and added gravestone recipe

### DIFF
--- a/AdventureNpc.cs
+++ b/AdventureNpc.cs
@@ -408,7 +408,7 @@ public class AdventureNpc : GlobalNPC
             npcLoot.Add(ItemDropRule.Common(ItemID.QueenSlimeTrophy, 10, 1, 1));
             npcLoot.Add(ItemDropRule.Common(ItemID.QueenSlimeMask, 7, 1, 3));
 
-            npcLoot.Add(ItemDropRule.OneFromOptions(1, ItemID.CrystalNinjaHelmet, ItemID.CrystalNinjaChestplate, ItemID.CrystalNinjaLeggings));
+            npcLoot.Add(ItemDropRule.FewFromOptions(2, 1, ItemID.CrystalNinjaHelmet, ItemID.CrystalNinjaChestplate, ItemID.CrystalNinjaLeggings));
             npcLoot.Add(ItemDropRule.OneFromOptions(1, ItemID.Smolstar, ItemID.QueenSlimeHook, ItemID.QueenSlimeMountSaddle));
         }
         if (npc.netID == NPCID.DungeonGuardian)
@@ -417,6 +417,28 @@ public class AdventureNpc : GlobalNPC
             npcLoot.RemoveWhere(rule => true);
             npcLoot.Add(ItemDropRule.Common(ItemID.Skull, 1, 1, 1)); // 1 in 20 chance (~5%)
 
+        }
+        if (npc.netID == NPCID.QueenBee)
+        {
+            // Clear existing loot
+            npcLoot.RemoveWhere(rule => true);
+
+            // Add your existing drops
+            npcLoot.Add(ItemDropRule.Common(ItemID.HiveWand, 3, 1, 1));
+            npcLoot.Add(ItemDropRule.Common(ItemID.QueenBeeTrophy, 10, 1, 1));
+            npcLoot.Add(ItemDropRule.Common(ItemID.BeeMask, 7, 1, 1));
+            npcLoot.Add(ItemDropRule.Common(ItemID.HoneyedGoggles, 20, 1, 1));
+            npcLoot.Add(ItemDropRule.Common(ItemID.BeeWax, 1, 16, 26));
+            npcLoot.Add(ItemDropRule.Common(ItemID.Nectar, 14, 1, 1));
+            npcLoot.Add(ItemDropRule.Common(ItemID.Beenade, 1, 10, 30));
+
+
+            npcLoot.Add(ItemDropRule.OneFromOptions(1, ItemID.BeeKeeper, ItemID.BeesKnees));
+            npcLoot.Add(ItemDropRule.OneFromOptions(1, ItemID.BeeGun, ItemID.HoneyComb));
+        }
+        if (npc.netID == NPCID.SkeletronHead)
+        {
+            npcLoot.Add(ItemDropRule.Common(ItemID.GoldenKey, 1, 1, 1));
         }
     }
 

--- a/System/RecipeManager.cs
+++ b/System/RecipeManager.cs
@@ -88,6 +88,11 @@ namespace PvPAdventure.System
                 .AddTile(476) // Shimmering Pool tile ID
                 .Register();
 
+            Recipe.Create(ItemID.Headstone)
+                .AddIngredient(ItemID.StoneBlock, 50)
+                .AddTile(TileID.HeavyWorkBench) 
+                .Register();
+
             //placeholder code before proper item replacments
             Recipe.Create(ItemID.Tabi)
                 .AddIngredient(ItemID.BlackBelt)
@@ -112,6 +117,7 @@ namespace PvPAdventure.System
             Recipe.Create(ItemID.BlizzardinaBottle)
                 .AddIngredient(ItemID.Fish)
                 .Register();
+
         }
     }
 }


### PR DESCRIPTION
-Queen bee now has two drop pools
Primary pool contains: 50% Bee Keeper, 50% Bee's Knees
Secondary pool contains: 50% Bee Gun, 50% honey comb

-Skeletron now drops a GOLDEN KEY

-Queen slime now drops 2 pieces of crystal assassin per boss

-You can craft headstones at heavy workbenches for 50 stone

And yes, I did just copy the changes from the changelog post I did