### PR TITLE
Pickaxe power changes

### DIFF
--- a/AdventureItem.cs
+++ b/AdventureItem.cs
@@ -85,4 +85,15 @@ public class AdventureItem : GlobalItem
 
     // This is likely unnecessary if we are overriding PrefixChance, but might as well.
     public override bool CanReforge(Item item) => !ModContent.GetInstance<AdventureConfig>().RemovePrefixes;
+
+    public class PickaxeAdjustments : GlobalItem
+    {
+        public override void SetDefaults(Item item)
+        {
+            if (item.type == ItemID.SpectrePickaxe || item.type == ItemID.ShroomiteDiggingClaw)
+            {
+                item.pick = 210;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Changes pickaxe power of Shrigging Claws and Specaxe to 210, allowing them to mine lihzahrd bricks. This allows people to mine into temple without needing to kill golem.