### PR TITLE
Makes Flask Buffs go away on death

### DIFF
--- a/AdventurePlayer.cs
+++ b/AdventurePlayer.cs
@@ -682,4 +682,30 @@ public class AdventurePlayer : ModPlayer
     {
         return $"{Player.whoAmI}/{Player.name}/{DiscordUser?.Id}";
     }
+
+    public class RemoveFlaskBuffsOnDeath : ModPlayer
+    {
+        // Array of buff IDs to remove on death
+        private readonly int[] buffsToRemove = { 71, 73, 74, 75, 76, 77, 78, 79 }; //Every single Flask buff that doesn't go away on death for some reason
+
+        public override void Kill(double damage, int hitDirection, bool pvp, PlayerDeathReason damageSource)
+        {
+           
+            for (int i = 0; i < Player.MaxBuffs; i++)
+            {
+                int buffType = Player.buffType[i];
+
+                
+                foreach (int buffId in buffsToRemove)
+                {
+                    if (buffType == buffId)
+                    {
+                        Player.DelBuff(i); // Remove the buff
+                        i--; // Adjust index since we removed a buff
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Flask buffs now go away when you die, they didn't before and because games were only three hours you only needed at most 6 flasks to last the entire game which was dumb.